### PR TITLE
Bruk app_id ved bruk av rapbase::statsServer

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -167,7 +167,7 @@ app_server = function(input, output, session) {
 
   # use stats
   rapbase::statsGuideServer("ltmv-stats", registryName = registry_name)
-  rapbase::statsServer("ltmv-stats", registryName = registry_name)
+  rapbase::statsServer("ltmv-stats", registryName = registry_name, app_id = Sys.getenv("FALK_APP_ID"))
 
   # export
   rapbase::exportGuideServer("ltmv-export", registry_name)


### PR DESCRIPTION
Ellers ser man loggen fra alle rapportek, og ikke kun ltmv sin.

Closes #45